### PR TITLE
Handlers option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ var generated = require('unist-util-generated');
 var definitions = require('mdast-util-definitions');
 var one = require('./one');
 var footer = require('./footer');
+var handlers = require('./handlers');
 
 /* Factory to transform. */
 function factory(tree, options) {
@@ -20,6 +21,7 @@ function factory(tree, options) {
   h.definition = definitions(tree, settings);
   h.footnotes = [];
   h.augment = augment;
+  h.handlers = xtend(handlers, (settings.handlers || {}));
 
   visit(tree, 'footnoteDefinition', visitor);
 

--- a/lib/one.js
+++ b/lib/one.js
@@ -5,7 +5,6 @@ module.exports = one;
 var u = require('unist-builder');
 var has = require('has');
 var all = require('./all');
-var handlers = require('./handlers');
 
 /* Transform an unknown node. */
 function unknown(h, node) {
@@ -19,7 +18,7 @@ function unknown(h, node) {
 /* Visit a node. */
 function one(h, node, parent) {
   var type = node && node.type;
-  var fn = has(handlers, type) ? handlers[type] : null;
+  var fn = has(h.handlers, type) ? h.handlers[type] : null;
 
   /* Fail on non-nodes. */
   if (!type) {

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,11 @@ default: `false`).  Only do this when compiling later with
 Set to `true` (default: `false`) to prefer the first when duplicate definitions
 are found.  The default behaviour is to prefer the last duplicate definition.
 
+###### `options.handlers`
+
+Object mapping [MDAST nodes](https://github.com/syntax-tree/mdast) to functions handling those elements.
+Take a look at [`lib/handlers/`][lib/handlers] for examples.
+
 ###### Returns
 
 [`HASTNode`][hast].

--- a/readme.md
+++ b/readme.md
@@ -51,8 +51,9 @@ are found.  The default behaviour is to prefer the last duplicate definition.
 
 ###### `options.handlers`
 
-Object mapping [MDAST nodes](https://github.com/syntax-tree/mdast) to functions handling those elements.
-Take a look at [`lib/handlers/`][lib/handlers] for examples.
+Object mapping [MDAST nodes][mdast] to functions 
+handling those elements.
+Take a look at [`lib/handlers/`][handlers] for examples.
 
 ###### Returns
 
@@ -105,3 +106,5 @@ Take a look at [`lib/handlers/`][lib/handlers] for examples.
 [unist-position]: https://github.com/syntax-tree/unist#location
 
 [hast-util-sanitize]: https://github.com/syntax-tree/hast-util-sanitize
+
+[handlers]: lib/handlers

--- a/test/handlers-option.js
+++ b/test/handlers-option.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var test = require('tape');
+var u = require('unist-builder');
+var to = require('..');
+var all = require('../lib/all');
+
+test('handlers option', function (t) {
+  var handlers = {
+    paragraph: function (h, node) {
+      node.children[0].value = 'changed';
+      return h(node, 'p', all(h, node));
+    }
+  };
+
+  t.deepEqual(
+    to(u('paragraph', [u('text', 'bravo')]), {handlers: handlers}),
+    u('element', {tagName: 'p', properties: {}}, [u('text', 'changed')]),
+    'should override default handler'
+  );
+
+  t.end();
+});

--- a/test/index.js
+++ b/test/index.js
@@ -28,3 +28,5 @@ require('./table.js');
 require('./text.js');
 require('./thematic-break.js');
 require('./yaml.js');
+
+require('./handlers-option.js');


### PR DESCRIPTION
This adds a handlers option to match what we recently added to hast-util-to-mdast.

I have a use case for this where I need to handle the `code` block in an alternate way.