### PR TITLE
Stop wrapping table cell contents with line breaks

### DIFF
--- a/lib/handlers/table.js
+++ b/lib/handlers/table.js
@@ -29,7 +29,7 @@ function table(h, node) {
       cell = row[pos];
       out[pos] = h(cell, name, {
         align: align[pos]
-      }, cell ? wrap(all(h, cell)) : []);
+      }, cell ? all(h, cell) : []);
     }
 
     result[index] = h(rows[index], 'tr', wrap(out, true));

--- a/test/table.js
+++ b/test/table.js
@@ -9,12 +9,16 @@ test('Table', function (t) {
     to(u('table', {align: ['left', 'right']}, [
       u('tableRow', [
         u('tableCell', [u('text', 'yankee')]),
-        u('tableCell', [u('text', 'zulu')])
+        u('tableCell', [
+          u('html', '<code>'),
+          u('text', 'zulu'),
+          u('html', '</code>')
+        ])
       ]),
       u('tableRow', [
         u('tableCell', [u('text', 'alpha')])
       ])
-    ])),
+    ]), {allowDangerousHTML: true}),
     u('element', {tagName: 'table', properties: {}}, [
       u('text', '\n'),
       u('element', {tagName: 'thead', properties: {}}, [
@@ -26,7 +30,9 @@ test('Table', function (t) {
           ]),
           u('text', '\n'),
           u('element', {tagName: 'th', properties: {align: 'right'}}, [
-            u('text', 'zulu')
+            u('raw', '<code>'),
+            u('text', 'zulu'),
+            u('raw', '</code>')
           ]),
           u('text', '\n')
         ]),


### PR DESCRIPTION
A fix for remarkjs/remark-html#23.