### PR TITLE
Improve handling of tight lists

### DIFF
--- a/lib/handlers/list-item.js
+++ b/lib/handlers/list-item.js
@@ -30,7 +30,7 @@ function listItem(h, node, parent) {
     for (index = 0; index < result.length; index++) {
       child = result[index]
       if (child.tagName === 'p') {
-        result.splice(i, 1, ...child.children)
+        result.splice.apply(result, [index, 1].concat(child.children))
         index += child.children.length
       }
     }

--- a/lib/handlers/list-item.js
+++ b/lib/handlers/list-item.js
@@ -12,9 +12,19 @@ function listItem(h, node, parent) {
   var head = children[0]
   var props = {}
   var result = all(h, node)
+  var container
+
+  /* A list item is loose if its parent list is loose, or if it directly
+   * contains two block-level elements */
+  var loose = false;
+  if (parent) {
+    loose = !!parent.loose;
+  } else if (children.length > 1) {
+    loose = true;
+  }
 
   /* Tight lists should not render 'paragraph' nodes as 'p' tags */
-  if (parent && !parent.loose) {
+  if (!loose) {
     for (var i = 0; i < result.length; i++) {
       if (result[i].tagName === 'p') {
         var len = result[i].children.length
@@ -25,15 +35,17 @@ function listItem(h, node, parent) {
   }
 
   if (typeof node.checked === 'boolean') {
-    if (!head || head.type !== 'paragraph') {
+    if (loose && (!head || head.type !== 'paragraph')) {
       result.unshift(h(null, 'p', []))
     }
 
-    if (result.length !== 0) {
-      result.unshift(u('text', ' '))
+    container = loose ? result[0].children : result
+
+    if (container.length !== 0) {
+      container.unshift(u('text', ' '))
     }
 
-    result.unshift(
+    container.unshift(
       h(null, 'input', {
         type: 'checkbox',
         checked: node.checked,
@@ -45,7 +57,7 @@ function listItem(h, node, parent) {
     props.className = ['task-list-item']
   }
 
-  if (result.length > 1) {
+  if (loose && result.length !== 0) {
     result = wrap(result, true)
   }
 

--- a/lib/handlers/list-item.js
+++ b/lib/handlers/list-item.js
@@ -13,23 +13,25 @@ function listItem(h, node, parent) {
   var props = {}
   var result = all(h, node)
   var container
+  var loose = false
+  var index
+  var child
 
   /* A list item is loose if its parent list is loose, or if it directly
    * contains two block-level elements */
-  var loose = false;
   if (parent) {
-    loose = !!parent.loose;
+    loose = Boolean(parent.loose)
   } else if (children.length > 1) {
-    loose = true;
+    loose = true
   }
 
   /* Tight lists should not render 'paragraph' nodes as 'p' tags */
   if (!loose) {
-    for (var i = 0; i < result.length; i++) {
-      if (result[i].tagName === 'p') {
-        var len = result[i].children.length
-        result.splice(i, 1, ...result[i].children)
-        i += len - 1
+    for (index = 0; index < result.length; index++) {
+      child = result[index]
+      if (child.tagName === 'p') {
+        result.splice(i, 1, ...child.children)
+        index += child.children.length
       }
     }
   }

--- a/lib/handlers/list-item.js
+++ b/lib/handlers/list-item.js
@@ -7,36 +7,22 @@ var wrap = require('../wrap')
 var all = require('../all')
 
 /* Transform a list-item. */
-function listItem(h, node, parent) {
+function listItem(h, node) {
   var children = node.children
   var head = children[0]
   var props = {}
-  var single = false
-  var result
-  var container
-
-  if (
-    (!parent || !parent.loose) &&
-    children.length === 1 &&
-    head.type === 'paragraph'
-  ) {
-    single = true
-  }
-
-  result = all(h, single ? head : node)
+  var result = all(h, node)
 
   if (typeof node.checked === 'boolean') {
-    if (!single && (!head || head.type !== 'paragraph')) {
+    if (!head || head.type !== 'paragraph') {
       result.unshift(h(null, 'p', []))
     }
 
-    container = single ? result : result[0].children
-
-    if (container.length !== 0) {
-      container.unshift(u('text', ' '))
+    if (result.length !== 0) {
+      result.unshift(u('text', ' '))
     }
 
-    container.unshift(
+    result.unshift(
       h(null, 'input', {
         type: 'checkbox',
         checked: node.checked,
@@ -48,7 +34,7 @@ function listItem(h, node, parent) {
     props.className = ['task-list-item']
   }
 
-  if (!single && result.length !== 0) {
+  if (result.length > 1) {
     result = wrap(result, true)
   }
 

--- a/lib/handlers/list-item.js
+++ b/lib/handlers/list-item.js
@@ -7,11 +7,22 @@ var wrap = require('../wrap')
 var all = require('../all')
 
 /* Transform a list-item. */
-function listItem(h, node) {
+function listItem(h, node, parent) {
   var children = node.children
   var head = children[0]
   var props = {}
   var result = all(h, node)
+
+  /* Tight lists should not render 'paragraph' nodes as 'p' tags */
+  if (parent && !parent.loose) {
+    for (var i = 0; i < result.length; i++) {
+      if (result[i].tagName === 'p') {
+        var len = result[i].children.length
+        result.splice(i, 1, ...result[i].children)
+        i += len - 1
+      }
+    }
+  }
 
   if (typeof node.checked === 'boolean') {
     if (!head || head.type !== 'paragraph') {

--- a/lib/handlers/paragraph.js
+++ b/lib/handlers/paragraph.js
@@ -5,11 +5,6 @@ module.exports = paragraph
 var all = require('../all')
 
 /* Transform a paragraph. */
-function paragraph(h, node, parent) {
-  /* Paragraphs in a tight list are not wrapped in <p> tags */
-  if (parent && parent.type === 'listItem' && !parent.loose) {
-    return all(h, node)
-  }
-
+function paragraph(h, node) {
   return h(node, 'p', all(h, node))
 }

--- a/lib/handlers/paragraph.js
+++ b/lib/handlers/paragraph.js
@@ -5,6 +5,11 @@ module.exports = paragraph
 var all = require('../all')
 
 /* Transform a paragraph. */
-function paragraph(h, node) {
+function paragraph(h, node, parent) {
+  /* Paragraphs in a tight list are not wrapped in <p> tags */
+  if (parent && parent.type === 'listItem' && !parent.loose) {
+    return all(h, node)
+  }
+
   return h(node, 'p', all(h, node))
 }

--- a/test/footnote.js
+++ b/test/footnote.js
@@ -50,11 +50,7 @@ test('Footnote', function(t) {
                 properties: {id: 'fn-1'}
               },
               [
-                u('text', '\n'),
-                u('element', {tagName: 'p', properties: {}}, [
-                  u('text', 'bravo')
-                ]),
-                u('text', '\n'),
+                u('text', 'bravo'),
                 u(
                   'element',
                   {
@@ -65,8 +61,7 @@ test('Footnote', function(t) {
                     }
                   },
                   [u('text', '↩')]
-                ),
-                u('text', '\n')
+                )
               ]
             ),
             u('text', '\n')
@@ -152,9 +147,7 @@ test('Footnote', function(t) {
                 properties: {id: 'fn-1'}
               },
               [
-                u('text', '\n'),
                 u('text', 'bravo'),
-                u('text', '\n'),
                 u(
                   'element',
                   {
@@ -165,8 +158,7 @@ test('Footnote', function(t) {
                     }
                   },
                   [u('text', '↩')]
-                ),
-                u('text', '\n')
+                )
               ]
             ),
             u('text', '\n'),
@@ -177,11 +169,7 @@ test('Footnote', function(t) {
                 properties: {id: 'fn-2'}
               },
               [
-                u('text', '\n'),
-                u('element', {tagName: 'p', properties: {}}, [
-                  u('text', 'charlie')
-                ]),
-                u('text', '\n'),
+                u('text', 'charlie'),
                 u(
                   'element',
                   {
@@ -192,8 +180,7 @@ test('Footnote', function(t) {
                     }
                   },
                   [u('text', '↩')]
-                ),
-                u('text', '\n')
+                )
               ]
             ),
             u('text', '\n')

--- a/test/list-item.js
+++ b/test/list-item.js
@@ -85,8 +85,6 @@ test('ListItem', function(t) {
   t.deepEqual(
     to(u('listItem', {checked: true}, [u('html', '<!--tango-->')])),
     u('element', {tagName: 'li', properties: {className: ['task-list-item']}}, [
-      u('text', '\n'),
-      u('element', {tagName: 'p', properties: {}}, [
         u(
           'element',
           {
@@ -99,8 +97,6 @@ test('ListItem', function(t) {
           },
           []
         )
-      ]),
-      u('text', '\n')
     ]),
     'should support checkboxes in `listItem`s without paragraph'
   )
@@ -114,8 +110,6 @@ test('ListItem', function(t) {
   t.deepEqual(
     to(u('listItem', {checked: true}, [])),
     u('element', {tagName: 'li', properties: {className: ['task-list-item']}}, [
-      u('text', '\n'),
-      u('element', {tagName: 'p', properties: {}}, [
         u(
           'element',
           {
@@ -128,8 +122,6 @@ test('ListItem', function(t) {
           },
           []
         )
-      ]),
-      u('text', '\n')
     ]),
     'should support checkboxes in `listItem`s without children'
   )
@@ -143,13 +135,11 @@ test('ListItem', function(t) {
       ])
     ),
     u('element', {tagName: 'li', properties: {}}, [
-      u('text', '\n'),
       u('element', {tagName: 'ul', properties: {}}, [
         u('text', '\n'),
         u('element', {tagName: 'li', properties: {}}, [u('text', 'Alpha')]),
         u('text', '\n')
       ]),
-      u('text', '\n')
     ]),
     'should support lists in `listItem`s'
   )

--- a/test/list-item.js
+++ b/test/list-item.js
@@ -85,18 +85,18 @@ test('ListItem', function(t) {
   t.deepEqual(
     to(u('listItem', {checked: true}, [u('html', '<!--tango-->')])),
     u('element', {tagName: 'li', properties: {className: ['task-list-item']}}, [
-        u(
-          'element',
-          {
-            tagName: 'input',
-            properties: {
-              type: 'checkbox',
-              checked: true,
-              disabled: true
-            }
-          },
-          []
-        )
+      u(
+        'element',
+        {
+          tagName: 'input',
+          properties: {
+            type: 'checkbox',
+            checked: true,
+            disabled: true
+          }
+        },
+        []
+      )
     ]),
     'should support checkboxes in `listItem`s without paragraph'
   )
@@ -110,18 +110,18 @@ test('ListItem', function(t) {
   t.deepEqual(
     to(u('listItem', {checked: true}, [])),
     u('element', {tagName: 'li', properties: {className: ['task-list-item']}}, [
-        u(
-          'element',
-          {
-            tagName: 'input',
-            properties: {
-              type: 'checkbox',
-              checked: true,
-              disabled: true
-            }
-          },
-          []
-        )
+      u(
+        'element',
+        {
+          tagName: 'input',
+          properties: {
+            type: 'checkbox',
+            checked: true,
+            disabled: true
+          }
+        },
+        []
+      )
     ]),
     'should support checkboxes in `listItem`s without children'
   )
@@ -139,7 +139,7 @@ test('ListItem', function(t) {
         u('text', '\n'),
         u('element', {tagName: 'li', properties: {}}, [u('text', 'Alpha')]),
         u('text', '\n')
-      ]),
+      ])
     ]),
     'should support lists in `listItem`s'
   )


### PR DESCRIPTION
<!--

Read the [contributing guidelines](https://github.com/remarkjs/remark/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Closes #123`. New features and bug fixes should come with tests.

-->

# Context

In markdown, "tight" lists are supposed to render text without paragraph tags:

```markdown
- item one
- item two
```

becomes:

```html
<ul>
<li>item one</li>
<li>item two</li>
</ul>
```

In remark, this _usually_ works, but it works in kind of a weird way. The original text is actually parsed to an MDAST tree that contains paragraph nodes:

```
root[1] (1:1-2:11, 0-21)
└─ list[2] (1:1-2:11, 0-21) [ordered=false][loose=false]
   ├─ listItem[1] (1:1-1:11, 0-10) [loose=false]
   │  └─ paragraph[1] (1:3-1:11, 2-10)
   │     └─ text: "item one" (1:3-1:11, 2-10)
   └─ listItem[1] (2:1-2:11, 11-21) [loose=false]
      └─ paragraph[1] (2:3-2:11, 13-21)
         └─ text: "item two" (2:3-2:11, 13-21)
```

And those tags are then removed by `mdast-util-to-hast`:

https://github.com/syntax-tree/mdast-util-to-hast/blob/1f8591e0b6163c437999e842774f66c9027cfc47/lib/handlers/list-item.js#L18-L24

```
root[1] (1:1-2:11, 0-21)
└─ element[5] (1:1-2:11, 0-21) [tagName="ul"]
   ├─ text: "\n"
   ├─ element[1] (1:1-1:11, 0-10) [tagName="li"]
   │  └─ text: "item one" (1:3-1:11, 2-10)
   ├─ text: "\n"
   ├─ element[1] (2:1-2:11, 11-21) [tagName="li"]
   │  └─ text: "item two" (2:3-2:11, 13-21)
   └─ text: "\n"
```

# The Problem

This usually results in correct HTML output, even though it's a bit weird to have "paragraph" nodes that don't then become "p" tags. However! This only works if the tight list item has a single child, which means that in cases like

```markdown
- item one
  - item two
```

we would expect to render to 

```html
<ul>
<li>item one
<ul>
<li>item two</li>
</ul>
</li>
</ul>
```

but instead get

```html
<ul>
<li>
<p>item1</p>
<ul>
<li>item2</li>
</ul>
</li>
</ul>
```

Because the node in the intermediate MDAST doesn't have just a single child:

```
root[1] (1:1-2:13, 0-23)
└─ list[1] (1:1-2:13, 0-23) [ordered=false][loose=false]
   └─ listItem[2] (1:1-2:13, 0-23) [loose=false]
      ├─ paragraph[1] (1:3-1:11, 2-10)
      │  └─ text: "item one" (1:3-1:11, 2-10)
      └─ list[1] (2:3-2:13, 13-23) [ordered=false][loose=false]
         └─ listItem[1] (2:3-2:13, 13-23) [loose=false]
            └─ paragraph[1] (2:5-2:13, 15-23)
               └─ text: "item two" (2:5-2:13, 15-23)
```

# The Solution

There are a couple of potential solutions here; one of them would be to avoid creating those unnecessary "paragraph" nodes in the first place, but another is toupgrade `mdast-util-to-hast` to be able to deal with this case as well. This latter solution is outlined in this PR.

I still need to fix the tests that are affected by this change and write new ones for this new functionality, but before I invest that time I want to get your thoughts on the validity of pursuing this fix as opposed to the other one.