### PR TITLE
Support info string in code blocks

### DIFF
--- a/lib/handlers/code.js
+++ b/lib/handlers/code.js
@@ -15,7 +15,7 @@ function code(h, node) {
   if (lang) {
     props.className = ['language-' + lang]
   }
-  
+
   if (meta) {
     props['data-meta'] = meta
   }

--- a/lib/handlers/code.js
+++ b/lib/handlers/code.js
@@ -9,10 +9,15 @@ var u = require('unist-builder')
 function code(h, node) {
   var value = node.value ? detab(node.value + '\n') : ''
   var lang = node.lang && node.lang.match(/^[^ \t]+(?=[ \t]|$)/)
+  var meta = node.meta
   var props = {}
 
   if (lang) {
     props.className = ['language-' + lang]
+  }
+  
+  if (meta) {
+    props['data-meta'] = meta
   }
 
   return h(node.position, 'pre', [h(node, 'code', props, [u('text', value)])])

--- a/test/code.js
+++ b/test/code.js
@@ -35,5 +35,29 @@ test('Code', function(t) {
     'should transform `code` to a `pre` element with language class'
   )
 
+  t.deepEqual(
+    to(
+      u(
+        'code',
+        {lang: 'js', meta: 'line-highlight=2 line-numbers=true'},
+        'india()'
+      )
+    ),
+    u('element', {tagName: 'pre', properties: {}}, [
+      u(
+        'element',
+        {
+          tagName: 'code',
+          properties: {
+            className: ['language-js'],
+            'data-meta': 'line-highlight=2 line-numbers=true'
+          }
+        },
+        [u('text', 'india()\n')]
+      )
+    ]),
+    'should transform `code` to a `pre` element with `data-meta` prop'
+  )
+
   t.end()
 })


### PR DESCRIPTION
Now that https://github.com/remarkjs/remark/pull/345 has landed, add support for `meta` prop to `mdast-util-to-hast` as well. Ok to put this on `data-meta`? Also, is the node.lang regex still needed?