### PR TITLE
Pass meta to code props

### DIFF
--- a/lib/handlers/code.js
+++ b/lib/handlers/code.js
@@ -7,11 +7,14 @@ var u = require('unist-builder')
 
 function code(h, node) {
   var value = node.value ? detab(node.value + '\n') : ''
-  var lang = node.lang && node.lang.match(/^[^ \t]+(?=[ \t]|$)/)
   var props = {}
 
-  if (lang) {
-    props.className = ['language-' + lang]
+  if (node.lang) {
+    props.className = ['language-' + node.lang]
+  }
+
+  if (node.meta) {
+    props.meta = node.meta
   }
 
   return h(node.position, 'pre', [h(node, 'code', props, [u('text', value)])])

--- a/test/code.js
+++ b/test/code.js
@@ -24,15 +24,18 @@ test('Code', function(t) {
   )
 
   t.deepEqual(
-    to(u('code', {lang: 'js'}, 'india()')),
+    to(u('code', {lang: 'js', meta: 'repl'}, 'india()')),
     u('element', {tagName: 'pre', properties: {}}, [
       u(
         'element',
-        {tagName: 'code', properties: {className: ['language-js']}},
+        {
+          tagName: 'code',
+          properties: {className: ['language-js'], meta: 'repl'}
+        },
         [u('text', 'india()\n')]
       )
     ]),
-    'should transform `code` to a `pre` element with language class'
+    'should transform `code` to a `pre` element with language class and meta attribute'
   )
 
   t.end()


### PR DESCRIPTION
Since remark now supports `meta` in code nodes, does it make sense to pass this to the rehype node as well? By adding this to the core we would have a standardized place for it, so rehype plugins using `meta` can all look in the same place.

This would, of course, be a breaking change.