### PR TITLE
fix: cast identifiers to strings to avoid type error

### DIFF
--- a/lib/footer.js
+++ b/lib/footer.js
@@ -18,7 +18,9 @@ function generateFootnotes(h) {
   var tail
 
   while (++index < length) {
-    def = footnoteById[footnoteOrder[index].toUpperCase()]
+    // Ensures that .toUpperCase() doesn’t fail in the event of an integer ID
+    var footnoteId = String(footnoteOrder[index])
+    def = footnoteById[footnoteId.toUpperCase()]
 
     if (!def) {
       continue

--- a/lib/index.js
+++ b/lib/index.js
@@ -85,7 +85,7 @@ function factory(tree, options) {
   }
 
   function onfootnotedefinition(definition) {
-    var id = definition.identifier.toUpperCase()
+    var id = String(definition.identifier).toUpperCase()
 
     // Mimick CM behavior of link definitions.
     // See: <https://github.com/syntax-tree/mdast-util-definitions/blob/8d48e57/index.js#L26>.


### PR DESCRIPTION
If using a plugin that converts footnote IDs to integers (e.g. `remark-numbered-footnotes`), the attempts to run `toUpperCase()` on the identifier fails. This casts identifiers to strings to ensure that the `toUpperCase()` call won’t fail.

This would close the issues encountered in https://github.com/gatsbyjs/gatsby/issues/16578