### PR TITLE
Add custom unknownHandler

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,7 @@ function factory(tree, options) {
   h.footnoteOrder = []
   h.augment = augment
   h.handlers = Object.assign({}, handlers, settings.handlers)
+  h.unknownHandler = settings.unknownHandler
 
   visit(tree, 'footnoteDefinition', onfootnotedefinition)
 

--- a/lib/one.js
+++ b/lib/one.js
@@ -19,7 +19,7 @@ function unknown(h, node) {
 // Visit a node.
 function one(h, node, parent) {
   var type = node && node.type
-  var fn = own.call(h.handlers, type) ? h.handlers[type] : null
+  var fn = own.call(h.handlers, type) ? h.handlers[type] : h.unknownHandler
 
   // Fail on non-nodes.
   if (!type) {

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,15 @@ The default behaviour is to prefer the last duplicate definition.
 Object mapping [mdast][] [nodes][mdast-node] to functions handling them.
 Take a look at [`lib/handlers/`][handlers] for examples.
 
+###### `options.unknownHandler`
+
+Handler for all unknown nodes.
+
+Default behaviour:
+
+*   Unknown nodes with [`children`][child] are transformed to `div` elements
+*   Unknown nodes with `value` are transformed to [`text`][hast-text] nodes
+
 ##### Returns
 
 [`HastNode`][hast-node].
@@ -93,8 +102,6 @@ Take a look at [`lib/handlers/`][handlers] for examples.
     [`remark-frontmatter`][remark-frontmatter])
 *   [`html`][mdast-html] nodes are ignored if `allowDangerousHTML` is `false`
 *   [`position`][position]s are properly patched
-*   Unknown nodes with [`children`][child] are transformed to `div` elements
-*   Unknown nodes with `value` are transformed to [`text`][hast-text] nodes
 *   [`node.data.hName`][hname] configures the hast element’s tag-name
 *   [`node.data.hProperties`][hproperties] is mixed into the hast element’s
     properties

--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,7 @@ Only do this when using [`hast-util-to-html`][to-html]
 
 Set to `true` (default: `false`) to prefer the first when duplicate definitions
 are found.
-The default behaviour is to prefer the last duplicate definition.
+The default behavior is to prefer the last duplicate definition.
 
 ###### `options.handlers`
 
@@ -87,7 +87,7 @@ Take a look at [`lib/handlers/`][handlers] for examples.
 
 Handler for all unknown nodes.
 
-Default behaviour:
+Default behavior:
 
 *   Unknown nodes with [`children`][child] are transformed to `div` elements
 *   Unknown nodes with `value` are transformed to [`text`][hast-text] nodes

--- a/test/handlers-option.js
+++ b/test/handlers-option.js
@@ -21,7 +21,7 @@ test('handlers option', function(t) {
 
   var customMdast = u('paragraph', [
     u('custom', 'with value'),
-    u('custom', [u('img', {src: 'with-children.png'})]),
+    u('custom', [u('image', {url: 'with-children.png'})]),
     u('text', 'bravo')
   ])
 
@@ -30,7 +30,14 @@ test('handlers option', function(t) {
     u('element', {tagName: 'p', properties: {}}, [
       u('text', 'with value'),
       u('element', {tagName: 'div', properties: {}}, [
-        u('element', {tagName: 'div', properties: {}}, [])
+        u(
+          'element',
+          {
+            tagName: 'img',
+            properties: {src: 'with-children.png', alt: undefined}
+          },
+          []
+        )
       ]),
       u('text', 'bravo')
     ]),
@@ -45,7 +52,7 @@ test('handlers option', function(t) {
     }),
     u('element', {tagName: 'p', properties: {}}, [
       u('custom', 'with value'),
-      u('custom', [u('img', {src: 'with-children.png'})]),
+      u('custom', [u('image', {url: 'with-children.png'})]),
       u('text', 'bravo')
     ]),
     'should use custom unknown-handler'

--- a/test/handlers-option.js
+++ b/test/handlers-option.js
@@ -19,5 +19,32 @@ test('handlers option', function(t) {
     'should override default handler'
   )
 
+  var mdastWithMetaNode = u('paragraph', [
+    u('meta-node', 'meta'),
+    u('text', 'bravo')
+  ])
+
+  t.deepEqual(
+    to(mdastWithMetaNode, {}),
+    u('element', {tagName: 'p', properties: {}}, [
+      u('text', 'meta'),
+      u('text', 'bravo')
+    ]),
+    'should use default unknown-handler'
+  )
+
+  t.deepEqual(
+    to(mdastWithMetaNode, {
+      unknownHandler: function(n, node) {
+        return node
+      }
+    }),
+    u('element', {tagName: 'p', properties: {}}, [
+      u('meta-node', 'meta'),
+      u('text', 'bravo')
+    ]),
+    'should use custom unknown-handler'
+  )
+
   t.end()
 })

--- a/test/handlers-option.js
+++ b/test/handlers-option.js
@@ -19,28 +19,33 @@ test('handlers option', function(t) {
     'should override default handler'
   )
 
-  var mdastWithMetaNode = u('paragraph', [
-    u('meta-node', 'meta'),
+  var customMdast = u('paragraph', [
+    u('custom', 'with value'),
+    u('custom', [u('img', {src: 'with-children.png'})]),
     u('text', 'bravo')
   ])
 
   t.deepEqual(
-    to(mdastWithMetaNode, {}),
+    to(customMdast, {}),
     u('element', {tagName: 'p', properties: {}}, [
-      u('text', 'meta'),
+      u('text', 'with value'),
+      u('element', {tagName: 'div', properties: {}}, [
+        u('element', {tagName: 'div', properties: {}}, [])
+      ]),
       u('text', 'bravo')
     ]),
     'should use default unknown-handler'
   )
 
   t.deepEqual(
-    to(mdastWithMetaNode, {
+    to(customMdast, {
       unknownHandler: function(n, node) {
         return node
       }
     }),
     u('element', {tagName: 'p', properties: {}}, [
-      u('meta-node', 'meta'),
+      u('custom', 'with value'),
+      u('custom', [u('img', {src: 'with-children.png'})]),
       u('text', 'bravo')
     ]),
     'should use custom unknown-handler'


### PR DESCRIPTION
As described in #36 this PR adds a new option `unknownHandler` to transform unknown nodes to HAST.