### PR TITLE
Rename 'allowDangerousHTML' to 'allowDangerousHtml'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,10 +13,21 @@ var handlers = require('./handlers')
 
 var own = {}.hasOwnProperty
 
+var deprecationWarningIssued = false
+
 // Factory to transform.
 function factory(tree, options) {
   var settings = options || {}
-  var dangerous = settings.allowDangerousHTML
+
+  // Issue a warning if the deprecated tag 'allowDangerousHTML' is used
+  if (settings.allowDangerousHTML !== undefined && !deprecationWarningIssued) {
+    deprecationWarningIssued = true
+    console.warn(
+      'Deprecation warning: `allowDangerousHTML` is a nonstandard option, use `allowDangerousHtml` instead'
+    )
+  }
+
+  var dangerous = settings.allowDangerousHtml || settings.allowDangerousHTML
   var footnoteById = {}
 
   h.dangerous = dangerous

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ function factory(tree, options) {
   if (settings.allowDangerousHTML !== undefined && !deprecationWarningIssued) {
     deprecationWarningIssued = true
     console.warn(
-      'Deprecation warning: `allowDangerousHTML` is a nonstandard option, use `allowDangerousHtml` instead'
+      'mdast-util-to-hast: deprecation: `allowDangerousHTML` is nonstandard, use `allowDangerousHtml` instead'
     )
   }
 

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ Transform the given [mdast][] [tree][] to a [hast][] [tree][].
 
 ##### Options
 
-###### `options.allowDangerousHTML`
+###### `options.allowDangerousHtml`
 
 Whether to allow [`html`][mdast-html] nodes and inject them as raw HTML
 (`boolean`, default: `false`).
@@ -100,7 +100,7 @@ Default behavior:
 
 *   [`yaml`][mdast-yaml] and `toml` nodes are ignored (created by
     [`remark-frontmatter`][remark-frontmatter])
-*   [`html`][mdast-html] nodes are ignored if `allowDangerousHTML` is `false`
+*   [`html`][mdast-html] nodes are ignored if `allowDangerousHtml` is `false`
 *   [`position`][position]s are properly patched
 *   [`node.data.hName`][hname] configures the hast element’s tag-name
 *   [`node.data.hProperties`][hproperties] is mixed into the hast element’s
@@ -217,7 +217,7 @@ Yields, in [hast][] (**note**: the `pre` and `language-js` class are normal
 Use of `mdast-util-to-hast` can open you up to a
 [cross-site scripting (XSS)][xss] attack.
 Embedded hast properties (`hName`, `hProperties`, `hChildren`), custom handlers,
-and the `allowDangerousHTML` option all provide openings.
+and the `allowDangerousHtml` option all provide openings.
 
 The following example shows how a script is injected where a benign code block
 is expected with embedded hast properties:
@@ -263,7 +263,7 @@ Yields:
 <h1>Hello</h1>
 ```
 
-Passing `allowDangerousHTML: true` to `mdast-util-to-hast` is typically still
+Passing `allowDangerousHtml: true` to `mdast-util-to-hast` is typically still
 not enough to run unsafe code:
 
 ```html
@@ -271,7 +271,7 @@ not enough to run unsafe code:
 &#x3C;script>alert(3)&#x3C;/script>
 ```
 
-If `allowDangerousHTML: true` is also given to `hast-util-to-html` (or
+If `allowDangerousHtml: true` is also given to `hast-util-to-html` (or
 `rehype-stringify`), the unsafe code runs:
 
 ```html

--- a/test/html.js
+++ b/test/html.js
@@ -8,9 +8,15 @@ test('HTML', function(t) {
   t.equal(to(u('html', '<mike></mike>')), null, 'should ignore `html`')
 
   t.deepEqual(
+    to(u('html', '<mike></mike>'), {allowDangerousHtml: true}),
+    u('raw', '<mike></mike>'),
+    'should transform `html` to `raw` if `allowDangerousHtml` is given'
+  )
+
+  t.deepEqual(
     to(u('html', '<mike></mike>'), {allowDangerousHTML: true}),
     u('raw', '<mike></mike>'),
-    'should transform `html` to `raw` if `allowDangerousHTML` is given'
+    'should still transform `html` to `raw` if deprecated `allowDangerousHTML` is given'
   )
 
   t.end()

--- a/test/table.js
+++ b/test/table.js
@@ -18,7 +18,7 @@ test('Table', function(t) {
         ]),
         u('tableRow', [u('tableCell', [u('text', 'alpha')])])
       ]),
-      {allowDangerousHTML: true}
+      {allowDangerousHtml: true}
     ),
     u('element', {tagName: 'table', properties: {}}, [
       u('text', '\n'),


### PR DESCRIPTION
Fixes #38 by renaming the option `allowDangerousHTML` to `allowDangerousHtml`.  The old option is still acceptable, but outputs a deprecation warning on the first call to `factory()`.  Also updates docs and adds a test case for the renamed option.

<!--

Read the [contributing guidelines](https://github.com/syntax-tree/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/syntax-tree/.github/blob/master/support.md
https://github.com/syntax-tree/.github/blob/master/contributing.md
-->
