### PR TITLE
Add types

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 coverage/
 mdast-util-to-hast.js
 mdast-util-to-hast.min.js
+*.md

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "prettier": true,
     "esnext": false,
     "ignores": [
+      "**/*.ts",
       "mdast-util-to-hast.js"
     ],
     "rules": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "xo": "^0.28.0"
   },
   "scripts": {
-    "format": "remark . -qfo && prettier --write \"**/*.js\" && xo --fix",
+    "format": "remark . -qfo && prettier --write . && xo --fix",
     "build-bundle": "browserify index.js -s mdastUtilToHast > mdast-util-to-hast.js",
     "build-mangle": "browserify index.js -s mdastUtilToHast -p tinyify > mdast-util-to-hast.min.js",
     "build": "npm run build-bundle && npm run build-mangle",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,11 @@
   ],
   "types": "types/index.d.ts",
   "dependencies": {
+    "@types/mdast": "^3.0.3",
     "collapse-white-space": "^1.0.0",
     "detab": "^2.0.0",
     "dtslint": "^3.4.1",
-    "mdast-util-definitions": "^2.0.0",
+    "mdast-util-definitions": "^3.0.0",
     "mdurl": "^1.0.0",
     "trim-lines": "^1.0.0",
     "unist-builder": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,14 @@
   ],
   "files": [
     "lib",
-    "index.js"
+    "index.js",
+    "types/index.d.ts"
   ],
+  "types": "types/index.d.ts",
   "dependencies": {
     "collapse-white-space": "^1.0.0",
     "detab": "^2.0.0",
+    "dtslint": "^3.4.1",
     "mdast-util-definitions": "^2.0.0",
     "mdurl": "^1.0.0",
     "trim-lines": "^1.0.0",
@@ -56,7 +59,8 @@
     "build": "npm run build-bundle && npm run build-mangle",
     "test-api": "node test",
     "test-coverage": "nyc --reporter lcov tape test/index.js",
-    "test": "npm run format && npm run build && npm run test-coverage"
+    "test-types": "dtslint types",
+    "test": "npm run format && npm run build && npm run test-coverage && npm run test-types"
   },
   "nyc": {
     "check-coverage": true,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,58 @@
+// Minimum TypeScript Version: 3.2
+import {Node} from 'unist'
+
+declare namespace toHast {
+  type Handler = (h: any, node: Node) => any
+
+  interface Options {
+    /**
+     * Whether to allow [`html`](https://github.com/syntax-tree/mdast#html) nodes and inject them as raw HTML
+     *
+     * Only do this when using [`hast-util-to-html`](https://github.com/syntax-tree/hast-util-to-html)
+     * ([`rehype-stringify`](https://github.com/rehypejs/rehype/tree/master/packages/rehype-stringify)) or
+     * [`hast-util-raw`](https://github.com/syntax-tree/hast-util-raw)
+     * ([`rehype-raw`](https://github.com/rehypejs/rehype-raw)) later: `raw` nodes are not a standard part of
+     * [hast](https://github.com/syntax-tree/hast).
+     *
+     * @default false
+     */
+    allowDangerousHtml?: boolean
+
+    /**
+     * Set to `true` to prefer the first when duplicate definitions are found.
+     *
+     * The default behavior is to prefer the last duplicate definition.
+     *
+     * @default false
+     */
+    commonmark?: boolean
+
+    /**
+     * Object mapping [mdast](https://github.com/syntax-tree/mdast)
+     * [nodes](https://github.com/syntax-tree/mdast#nodes) to functions handling them.
+     * Take a look at
+     * [`lib/handlers/`](https://github.com/syntax-tree/mdast-util-to-hast/blob/master/lib/handlers)
+     * for examples.
+     */
+    handlers?: {[type: string]: Handler}
+
+    /**
+     * Handler for all unknown nodes.
+     *
+     * Default behavior:
+     *
+     * * Unknown nodes with [`children`][child] are transformed to `div` elements
+     * * Unknown nodes with `value` are transformed to [`text`][hast-text] nodes
+     */
+    unknownHandler?: Handler
+  }
+}
+
+/**
+ * Transform the given [mdast](https://github.com/syntax-tree/mdast)
+ * [tree](https://github.com/syntax-tree/unist#tree) to a
+ * [hast](https://github.com/syntax-tree/hast) [tree](https://github.com/syntax-tree/unist#tree).
+ */
+declare function toHast(node: Node, options?: toHast.Options): Node
+
+export = toHast

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,22 @@
 import {Node} from 'unist'
 
 declare namespace toHast {
-  type Handler = (h: any, node: Node) => any
+  interface H {
+    dangerous?: boolean
+    definitions: any
+    footNoteById: object
+    footnoreOrder: string[]
+    handlers: Handlers
+    unknownHandler: Handler
+    (node: Node, tagName: string, props?: object, children?: Node[]): Node
+    augment(left: Node, right: Node): Node
+  }
+
+  type Handler = (h: H, node: Node) => any
+
+  interface Handlers {
+    [type: string]: Handler
+  }
 
   interface Options {
     /**
@@ -34,7 +49,7 @@ declare namespace toHast {
      * [`lib/handlers/`](https://github.com/syntax-tree/mdast-util-to-hast/blob/master/lib/handlers)
      * for examples.
      */
-    handlers?: {[type: string]: Handler}
+    handlers?: Handlers
 
     /**
      * Handler for all unknown nodes.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,11 +1,13 @@
 // Minimum TypeScript Version: 3.2
+import {Definition} from 'mdast'
+import {DefinitionCache} from 'mdast-util-definitions'
 import {Node} from 'unist'
 
 declare namespace toHast {
   interface H {
     dangerous?: boolean
-    definitions: any
-    footNoteById: object
+    definition: DefinitionCache
+    footNoteById: Definition
     footnoreOrder: string[]
     handlers: Handlers
     unknownHandler: Handler

--- a/types/mdast-util-to-hast-tests.ts
+++ b/types/mdast-util-to-hast-tests.ts
@@ -8,7 +8,27 @@ toHast(
   {
     handlers: {
       foo(h, node) {
-        return h(node)
+        return h(node, 'p')
+      }
+    }
+  }
+)
+toHast(
+  {type: ''},
+  {
+    handlers: {
+      foo(h, node) {
+        return h(node, 'p', {foo: 'bar'})
+      }
+    }
+  }
+)
+toHast(
+  {type: ''},
+  {
+    handlers: {
+      foo(h, node) {
+        return h(node, 'p', {}, [{type: ''}])
       }
     }
   }
@@ -17,7 +37,7 @@ toHast(
   {type: ''},
   {
     unknownHandler(h, node) {
-      return h(node)
+      return h(node, 'div')
     }
   }
 )

--- a/types/mdast-util-to-hast-tests.ts
+++ b/types/mdast-util-to-hast-tests.ts
@@ -1,0 +1,23 @@
+import toHast = require('mdast-util-to-hast')
+
+toHast({type: ''})
+toHast({type: ''}, {allowDangerousHtml: true})
+toHast({type: ''}, {commonmark: true})
+toHast(
+  {type: ''},
+  {
+    handlers: {
+      foo(h, node) {
+        return h(node)
+      }
+    }
+  }
+)
+toHast(
+  {type: ''},
+  {
+    unknownHandler(h, node) {
+      return h(node)
+    }
+  }
+)

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "lib": ["es2015"],
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "mdast-util-to-hast": ["index.d.ts"]
+    }
+  }
+}

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "dtslint/dtslint.json",
+  "rules": {
+    "no-redundant-jsdoc": false,
+    "semicolon": false,
+    "whitespace": false
+  }
+}


### PR DESCRIPTION
Add TypeScript type definitions.

Prettier is now applied to the entire project, and markdown files are properly excluded.