### PR TITLE
Add type dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
   ],
   "types": "types/index.d.ts",
   "dependencies": {
+    "@types/mdast": "^3.0.0",
+    "@types/unist": "^2.0.3",
     "collapse-white-space": "^1.0.0",
     "detab": "^2.0.0",
     "mdast-util-definitions": "^3.0.0",
@@ -42,7 +44,6 @@
     "unist-util-visit": "^2.0.0"
   },
   "devDependencies": {
-    "@types/mdast": "^3.0.0",
     "browserify": "^16.0.0",
     "dtslint": "^3.0.0",
     "nyc": "^15.0.0",

--- a/readme.md
+++ b/readme.md
@@ -20,12 +20,6 @@
 npm install mdast-util-to-hast
 ```
 
-[npm][] with [TypeScript][] support:
-
-```sh
-npm install mdast-util-to-hast @types/mdast
-```
-
 ## Use
 
 Say we have the following `example.md`:

--- a/readme.md
+++ b/readme.md
@@ -340,8 +340,6 @@ abide by its terms.
 
 [npm]: https://docs.npmjs.com/cli/install
 
-[typescript]: https://www.typescriptlang.org
-
 [license]: license
 
 [author]: https://wooorm.com


### PR DESCRIPTION
The dependencies on `@types/unist` and `@types/mdast` are needed to consume
this package in TypeScript.

If this is not defined, all dependants need to define this dependency.

This would fix the build for remarkjs/remark-rehype#13 and all sava a lot of hassle for its dependants.