### PR TITLE
Prevent accessing hName from undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,10 +48,10 @@ function factory(tree, options) {
     var ctx
 
     // Handle `data.hName`, `data.hProperties, `data.hChildren`.
-    if (left && 'data' in left) {
+    if (left && left.data) {
       data = left.data
 
-      if (data && data.hName) {
+      if (data.hName) {
         if (right.type !== 'element') {
           right = {
             type: 'element',

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ function factory(tree, options) {
     if (left && 'data' in left) {
       data = left.data
 
-      if (data.hName) {
+      if (data && data.hName) {
         if (right.type !== 'element') {
           right = {
             type: 'element',


### PR DESCRIPTION
In v10.0.1 started getting the following error: 

```
TypeError: Cannot read property 'hName' of undefined
    at Function.augment (/Users/josemarluedke/code/oss/docfy/node_modules/mdast-util-to-hast/lib/index.js:54:16)
    at html (/Users/josemarluedke/code/oss/docfy/node_modules/mdast-util-to-hast/lib/handlers/html.js:9:26)
    at one (/Users/josemarluedke/code/oss/docfy/node_modules/mdast-util-to-hast/lib/one.js:29:51)
    at all (/Users/josemarluedke/code/oss/docfy/node_modules/mdast-util-to-hast/lib/all.js:16:14)
    at paragraph (/Users/josemarluedke/code/oss/docfy/node_modules/mdast-util-to-hast/lib/handlers/paragraph.js:8:23)
    at one (/Users/josemarluedke/code/oss/docfy/node_modules/mdast-util-to-hast/lib/one.js:29:51)
    at all (/Users/josemarluedke/code/oss/docfy/node_modules/mdast-util-to-hast/lib/all.js:16:14)
    at root (/Users/josemarluedke/code/oss/docfy/node_modules/mdast-util-to-hast/lib/handlers/root.js:10:41)
    at one (/Users/josemarluedke/code/oss/docfy/node_modules/mdast-util-to-hast/lib/one.js:29:51)
    at toHast (/Users/josemarluedke/code/oss/docfy/node_modules/mdast-util-to-hast/lib/index.js:121:14)
  - code: [undefined]
  - codeFrame: Cannot read property 'hName' of undefined
  - errorMessage: Cannot read property 'hName' of undefined
```

This solves that.