### PR TITLE
Add exports of `one`, `all` helpers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,3 @@
+export {all} from './lib/all.js'
+export {one} from './lib/one.js'
 export {toHast} from './lib/index.js'

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ Which when running with `node example` yields:
 
 ## API
 
-This package exports the following identifiers: `toHast`.
+This package exports the following identifiers: `toHast`, `all`, `one`
 There is no default export.
 
 ### `toHast(node[, options])`
@@ -216,6 +216,18 @@ Yields, in [hast][] (**note**: the `pre` and `language-js` class are normal
   }]
 }
 ```
+
+### `all(h, parent)`
+
+Helper function for writing custom handlers passed to `options.handlers`.
+Pass it `h` and a parent node (mdast) and it will turn the node’s children into
+an array of transformed nodes (hast).
+
+### `one(h, node, parent)`
+
+Helper function for writing custom handlers passed to `options.handlers`.
+Pass it `h`, a `node`, and its `parent` (mdast) and it will turn `node` into
+hast content.
 
 ## Security
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

re-export `all` and `one` from index.js, closes #53 

originally I thought we could also re-export `revert`, and `wrap`, but looking at the implementation, it looks like those 2 are quite specialized for processing only some type of node, so I refrain from re-exporting them..

<!--do not edit: pr-->
