### PR TITLE
Add improved performance on tons of whitespace

### DIFF
--- a/lib/handlers/text.js
+++ b/lib/handlers/text.js
@@ -15,11 +15,11 @@ export function text(h, node) {
     u(
       'text',
       String(node.value)
-        .replace(/^[ \t]*/gm, '')
+        .replace(/^[ \t]+/gm, '')
         .split('')
         .reverse()
         .join('')
-        .replace(/^[ \t]*/gm, '')
+        .replace(/^[ \t]+/gm, '')
         .split('')
         .reverse()
         .join('')

--- a/lib/handlers/text.js
+++ b/lib/handlers/text.js
@@ -3,6 +3,7 @@
  * @typedef {import('../index.js').Handler} Handler
  */
 
+import {trimLines} from 'trim-lines'
 import {u} from 'unist-builder'
 
 /**
@@ -10,19 +11,5 @@ import {u} from 'unist-builder'
  * @param {Text} node
  */
 export function text(h, node) {
-  return h.augment(
-    node,
-    u(
-      'text',
-      String(node.value)
-        .replace(/^[ \t]+/gm, '')
-        .split('')
-        .reverse()
-        .join('')
-        .replace(/^[ \t]+/gm, '')
-        .split('')
-        .reverse()
-        .join('')
-    )
-  )
+  return h.augment(node, u('text', trimLines(String(node.value))))
 }

--- a/lib/handlers/text.js
+++ b/lib/handlers/text.js
@@ -12,6 +12,11 @@ import {u} from 'unist-builder'
 export function text(h, node) {
   return h.augment(
     node,
-    u('text', String(node.value).replace(/[ \t]*(\r?\n|\r)[ \t]*/g, '$1'))
+    u(
+      'text',
+      String(node.value)
+        .replace(/[ \t]*$/gm, '')
+        .replace(/^[ \t]*/gm, '')
+    )
   )
 }

--- a/lib/handlers/text.js
+++ b/lib/handlers/text.js
@@ -15,8 +15,14 @@ export function text(h, node) {
     u(
       'text',
       String(node.value)
-        .replace(/[ \t]*$/gm, '')
         .replace(/^[ \t]*/gm, '')
+        .split('')
+        .reverse()
+        .join('')
+        .replace(/^[ \t]*/gm, '')
+        .split('')
+        .reverse()
+        .join('')
     )
   )
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "mdast-util-definitions": "^5.0.0",
     "mdurl": "^1.0.0",
     "micromark-util-sanitize-uri": "^1.0.0",
+    "trim-lines": "^3.0.1",
     "unist-builder": "^3.0.0",
     "unist-util-generated": "^2.0.0",
     "unist-util-position": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mdast-util-definitions": "^5.0.0",
     "mdurl": "^1.0.0",
     "micromark-util-sanitize-uri": "^1.0.0",
-    "trim-lines": "^3.0.1",
+    "trim-lines": "^3.0.0",
     "unist-builder": "^3.0.0",
     "unist-util-generated": "^2.0.0",
     "unist-util-position": "^4.0.0",

--- a/test/text.js
+++ b/test/text.js
@@ -64,12 +64,19 @@ test('Nodes', (t) => {
   t.end()
 })
 
-test('efficiency', {timeout: 1000}, (t) => {
+test('Nodes Efficiency', (t) => {
+  const timeout = setTimeout(() => {
+    t.fail('should process lots of whitespace efficiently')
+  }, 10)
+
   t.deepEqual(
     toHast(u('text', `1${' '.repeat(70_000)}2`)),
     u('text', `1${' '.repeat(70_000)}2`),
     'should be efficient on excessive whitespace'
   )
 
-  t.end()
+  setTimeout(() => {
+    clearTimeout(timeout)
+    t.end()
+  }, 0)
 })

--- a/test/text.js
+++ b/test/text.js
@@ -63,3 +63,13 @@ test('Nodes', (t) => {
 
   t.end()
 })
+
+test('efficiency', {timeout: 1000}, (t) => {
+  t.deepEqual(
+    toHast(u('text', `1${' '.repeat(70_000)}2`)),
+    u('text', `1${' '.repeat(70_000)}2`),
+    'should be efficient on excessive whitespace'
+  )
+
+  t.end()
+})

--- a/test/text.js
+++ b/test/text.js
@@ -63,20 +63,3 @@ test('Nodes', (t) => {
 
   t.end()
 })
-
-test('Nodes Efficiency', (t) => {
-  const timeout = setTimeout(() => {
-    t.fail('should process lots of whitespace efficiently')
-  }, 10)
-
-  t.deepEqual(
-    toHast(u('text', `1${' '.repeat(70_000)}2`)),
-    u('text', `1${' '.repeat(70_000)}2`),
-    'should be efficient on excessive whitespace'
-  )
-
-  setTimeout(() => {
-    clearTimeout(timeout)
-    t.end()
-  }, 0)
-})


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Altered method of clearing out extraneous whitespace to handle non-matches more effectively. Approaches the problem using a regex with no backtracking to remove trailing whitespace, reverses the string and repeats to remove leading (now trailing) whitespace again. reverses the string to restore the original orientation.

I know it seems a little unorthodox to reverse the string, but because of how regex engines operate a leading whitespace regex like "[ \t]*$" runs inefficiently with lots of non-matching whitespace.

<!--do not edit: pr-->
