### PR TITLE
Add `footnoteLabelTagName`, `footnoteLabelProperties`

### DIFF
--- a/lib/footer.js
+++ b/lib/footer.js
@@ -3,7 +3,6 @@
  * @typedef {import('mdast').FootnoteDefinition} FootnoteDefinition
  * @typedef {import('hast').Element} Element
  * @typedef {import('hast').ElementContent} ElementContent
- * @typedef {import('hast').Properties} Properties
  * @typedef {import('./index.js').H} H
  */
 

--- a/lib/footer.js
+++ b/lib/footer.js
@@ -13,6 +13,7 @@ import {wrap} from './wrap.js'
 
 /**
  * @param {H} h
+ * @returns {Element|null}
  */
 export function footer(h) {
   let index = -1
@@ -109,7 +110,7 @@ export function footer(h) {
       {
         type: 'element',
         tagName: h.footnoteLabelTagName,
-        properties: {id: 'footnote-label', ...h.footnoteLabelProperties},
+        properties: JSON.parse(JSON.stringify(h.footnoteLabelProperties)),
         children: [u('text', h.footnoteLabel)]
       },
       {type: 'text', value: '\n'},

--- a/lib/footer.js
+++ b/lib/footer.js
@@ -3,6 +3,7 @@
  * @typedef {import('mdast').FootnoteDefinition} FootnoteDefinition
  * @typedef {import('hast').Element} Element
  * @typedef {import('hast').ElementContent} ElementContent
+ * @typedef {import('hast').Properties} Properties
  * @typedef {import('./index.js').H} H
  */
 

--- a/lib/footer.js
+++ b/lib/footer.js
@@ -108,8 +108,8 @@ export function footer(h) {
     children: [
       {
         type: 'element',
-        tagName: 'h2',
-        properties: {id: 'footnote-label', className: ['sr-only']},
+        tagName: h.footnoteLabelTagName,
+        properties: {id: 'footnote-label', ...h.footnoteLabelProperties},
         children: [u('text', h.footnoteLabel)]
       },
       {type: 'text', value: '\n'},

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,8 @@
  * @property {boolean} dangerous Whether HTML is allowed
  * @property {string} clobberPrefix Prefix to use to prevent DOM clobbering
  * @property {string} footnoteLabel Label to use to introduce the footnote section
+ * @property {string} footnoteLabelTagName HTML used for the footnote label
+ * @property {Properties} footnoteLabelProperties properties on the HTML tag used for the footnote label
  * @property {string} footnoteBackLabel Label to use to go back to a footnote call from the footnote section
  * @property {(identifier: string) => Definition|null} definition Definition cache
  * @property {Record<string, FootnoteDefinition>} footnoteById Footnote cache
@@ -73,6 +75,13 @@
  *   Label to use for the footnotes section.
  *   Affects screen reader users.
  *   Change it if you’re authoring in a different language.
+ * @property {string} [footnoteLabelTagName='h2']
+ *   HTML tag to use for the footnote label.
+ *   Can be changed to match your document structure and play well with your choice of css.
+ * @property {Properties} [footnoteLabelProperties={className: ['sr-only']}]
+ *   Properties to use on the footnote label.
+ *   A 'sr-only' class is added by default to hide this from sighted users.
+ *   Change it to make the label visible, or add classes for other purposes.
  * @property {string} [footnoteBackLabel='Back to content']
  *   Label to use from backreferences back to their footnote call.
  *   Affects screen reader users.
@@ -119,6 +128,8 @@ function factory(tree, options) {
       ? 'user-content-'
       : settings.clobberPrefix
   h.footnoteLabel = settings.footnoteLabel || 'Footnotes'
+  h.footnoteLabelTagName = settings.footnoteLabelTagName || 'h2'
+  h.footnoteLabelProperties = settings.footnoteLabelProperties || {className: ['sr-only']}
   h.footnoteBackLabel = settings.footnoteBackLabel || 'Back to content'
   h.definition = definitions(tree)
   h.footnoteById = footnoteById

--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,7 @@
  * @property {string} [footnoteLabelTagName='h2']
  *   HTML tag to use for the footnote label.
  *   Can be changed to match your document structure and play well with your choice of css.
- * @property {Properties} [footnoteLabelProperties={className: ['sr-only']}]
+ * @property {Properties} [footnoteLabelProperties={id: 'footnote-label', className: ['sr-only']}]
  *   Properties to use on the footnote label.
  *   A 'sr-only' class is added by default to hide this from sighted users.
  *   Change it to make the label visible, or add classes for other purposes.
@@ -129,7 +129,7 @@ function factory(tree, options) {
       : settings.clobberPrefix
   h.footnoteLabel = settings.footnoteLabel || 'Footnotes'
   h.footnoteLabelTagName = settings.footnoteLabelTagName || 'h2'
-  h.footnoteLabelProperties = settings.footnoteLabelProperties || {className: ['sr-only']}
+  h.footnoteLabelProperties = settings.footnoteLabelProperties || {id: 'footnote-label', className: ['sr-only']}
   h.footnoteBackLabel = settings.footnoteBackLabel || 'Back to content'
   h.definition = definitions(tree)
   h.footnoteById = footnoteById

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdast-util-to-hast",
-  "version": "12.1.1",
+  "version": "12.1.2",
   "description": "mdast utility to transform to hast",
   "license": "MIT",
   "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -176,6 +176,31 @@ Change it when the markdown is not in English.
 > They are supported by GitHub, so they can be enabled by using the utility
 > [`mdast-util-gfm`][mdast-util-gfm].
 
+###### `options.footnoteLabelTagName`
+
+HTML tag to use for the footnote label (`string`, default: `h2`).
+Can be changed to match your document structure and play well with your
+choice of css.
+
+> 👉 **Note**: this option affects footnotes.
+> Footnotes are not specified by CommonMark.
+> They are supported by GitHub, so they can be enabled by using the utility
+> [`mdast-util-gfm`][mdast-util-gfm].
+
+###### `options.footnoteLabelProperties`
+
+Properties to use on the footnote label (`object`, default: `{id: 
+'footnote-label', className: ['sr-only']}`).
+A `sr-only` class is added by default to hide this from sighted users.
+Change it to make the label visible, or add classes for other purposes.
+Provide an object with no className or no id to have a footnote label with
+either no class or no id, or an empty object to have none.
+
+> 👉 **Note**: this option affects footnotes.
+> Footnotes are not specified by CommonMark.
+> They are supported by GitHub, so they can be enabled by using the utility
+> [`mdast-util-gfm`][mdast-util-gfm].
+
 ###### `options.footnoteBackLabel`
 
 Label to use from backreferences back to their footnote call (`string`, default:

--- a/readme.md
+++ b/readme.md
@@ -193,7 +193,7 @@ Properties to use on the footnote label (`object`, default: `{id:
 'footnote-label', className: ['sr-only']}`).
 A `sr-only` class is added by default to hide this from sighted users.
 Change it to make the label visible, or add classes for other purposes.
-Provide an object with no className or no id to have a footnote label with
+Provide an object with no `className` or no `id` to have a footnote label with
 either no class or no id, or an empty object to have none.
 
 > 👉 **Note**: this option affects footnotes.


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This attempts to add options to let users configure the html tag that will be used for the footnote section label, as well as the properties that will go on it, as discussed in #63 

If this is deemed good enough, i will add changes to the readme to this PR in order for the new options to be documented.

<!--do not edit: pr-->
