### PR TITLE
Fix interface of Raw nodes to make them extendable again

### DIFF
--- a/complex-types.d.ts
+++ b/complex-types.d.ts
@@ -1,10 +1,9 @@
 import type {Literal} from 'hast'
 
-export type Raw = {
+export interface Raw extends Literal {
   type: 'raw'
-} & Literal
+}
 
-/* eslint-disable @typescript-eslint/consistent-type-definitions */
 declare module 'hast' {
   interface RootContentMap {
     raw: Raw
@@ -14,4 +13,3 @@ declare module 'hast' {
     raw: Raw
   }
 }
-/* eslint-enable @typescript-eslint/consistent-type-definitions */

--- a/complex-types.d.ts
+++ b/complex-types.d.ts
@@ -1,5 +1,6 @@
 import type {Literal} from 'hast'
 
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
 export interface Raw extends Literal {
   type: 'raw'
 }
@@ -13,3 +14,4 @@ declare module 'hast' {
     raw: Raw
   }
 }
+/* eslint-enable @typescript-eslint/consistent-type-definitions */

--- a/complex-types.d.ts
+++ b/complex-types.d.ts
@@ -1,17 +1,18 @@
 import type {Literal} from 'hast'
 
-/* eslint-disable @typescript-eslint/consistent-type-definitions */
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface Raw extends Literal {
   type: 'raw'
 }
 
 declare module 'hast' {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface RootContentMap {
     raw: Raw
   }
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface ElementContentMap {
     raw: Raw
   }
 }
-/* eslint-enable @typescript-eslint/consistent-type-definitions */


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Resolves #65.

This PR expands the `eslint-ignore` block introduced in https://github.com/syntax-tree/mdast-util-to-hast/commit/d97bcbdb5c8841e2a6083100a62c5e1bf8d55d6d to include the `Raw` interface to make it compatible with other declarations of the `Raw` type in other packages.

<!--do not edit: pr-->
