### PR TITLE
Use `module: node16` in types

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  * @typedef {import('./lib/index.js').Handler} Handler
  * @typedef {import('./lib/index.js').Handlers} Handlers
  * @typedef {import('./lib/index.js').H} H
- * @typedef {import('./complex-types').Raw} Raw
+ * @typedef {import('./complex-types.js').Raw} Raw
  */
 
 export {one, all} from './lib/traverse.js'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,13 +3,11 @@
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["ES2020"],
-    "module": "ES2020",
-    "moduleResolution": "node",
+    "module": "Node16",
     "allowJs": true,
     "checkJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
-    "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "strict": true
   }


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Adds a `.js` file extension to the type import for `complex-types.d.ts`. This is necessary for TypeScript projects using `"module": "Node16"` to compile without errors:

```
node_modules/mdast-util-to-hast/index.d.ts:5:26 - error TS2834: Relative import paths need explicit file
  extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding
  an extension to the import path.

5 export type Raw = import('./complex-types').Raw
                           ~~~~~~~~~~~~~~~~~
```

Yes, the `.js` file extension looks wrong... but it isn't. TypeScript will still resolve the import to the declaration file.

Without this change, the build still does not pass, due to three type errors, likely due to installing a newer TypeScript version than was used to write this package (package-lock.json is a good thing!), I opted not to fix this at this time.

cc: @gaurishhs

<!--do not edit: pr-->
