### PR TITLE
allow empty footnoteLabel

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -196,7 +196,10 @@ export function createState(tree, options) {
       ? 'user-content-'
       : settings.clobberPrefix
   // To do: next major: move to `state.options`.
-  state.footnoteLabel = settings.footnoteLabel || 'Footnotes'
+  state.footnoteLabel =
+    settings.footnoteLabel === undefined || settings.footnoteLabel === null
+      ? 'Footnotes'
+      : settings.footnoteLabel
   // To do: next major: move to `state.options`.
   state.footnoteLabelTagName = settings.footnoteLabelTagName || 'h2'
   // To do: next major: move to `state.options`.


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

The default value of footnoteLabel, `'Footnotes'`, should only be applied if the user did not specify its value (`undefined` or `null`). If the user specifies an empty string, footnoteLabel should have the value of an empty string.

The implementation copies the exact implementation for clobberPrefix, written ~5 lines above.

A user may want to use an empty string when they use `footnoteTagName: "hr"`
<!--do not edit: pr-->
