### PR TITLE
Fix `hProperties` on `tableCell`

### DIFF
--- a/lib/handlers/table-row.js
+++ b/lib/handlers/table-row.js
@@ -51,7 +51,7 @@ export function tableRow(state, node, parent) {
     if (cell) {
       result.children = state.all(cell)
       state.patch(cell, result)
-      result = state.applyData(node, result)
+      result = state.applyData(cell, result)
     }
 
     cells.push(result)

--- a/test/table.js
+++ b/test/table.js
@@ -30,7 +30,12 @@ test('table', async function (t) {
               children: [
                 {
                   type: 'tableCell',
-                  children: [{type: 'text', value: 'charlie'}]
+                  children: [{type: 'text', value: 'charlie'}],
+                  data: {
+                    hProperties: {
+                      className: ['foo', 'bar']
+                    }
+                  }
                 }
               ]
             }
@@ -60,7 +65,7 @@ test('table', async function (t) {
           '\n',
           h('tr', [
             '\n',
-            h('td', {align: 'left'}, 'charlie'),
+            h('td', {align: 'left', class: 'foo bar'}, 'charlie'),
             '\n',
             h('td', {align: 'right'}),
             '\n'

--- a/test/table.js
+++ b/test/table.js
@@ -65,7 +65,7 @@ test('table', async function (t) {
           '\n',
           h('tr', [
             '\n',
-            h('td', {align: 'left', class: 'foo bar'}, 'charlie'),
+            h('td', {align: 'left', className: ['foo', ''bar']}, 'charlie'),
             '\n',
             h('td', {align: 'right'}),
             '\n'


### PR DESCRIPTION
Fix `data.hProperties` not working for tableCell

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This pull request addresses an issue where the data.hProperties property was not being properly applied to tableCell elements in the mdast-util-to-hast library. The problem originates from the loop processing of children within the table-row.js file, where the state.applyData function is being passed the parent tableRow instead of the tableCell itself.

<!--do not edit: pr-->
